### PR TITLE
Feature windows install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,24 +63,25 @@ Install from latest github source:
 
    ``python -m pip install --no-deps --no-build-isolation --user git+https://github.com/AppliedMathematicsANU/pyemblite.git#egg=pyemblite``
 
-If you're on windows, you need to have embree3 installed and in the default 
-location (``C:\Program Files\Intel\Embree3\``) before you install pyemblite. 
-To complicate matters, the most recent versions no longer come with an installer, 
-the last version to do so is this one:
+If you're on windows, you need to have embree3 installed. 
+Use the most recent version, make sure you unzip the contents of the 
+zip file into a folder where the MS build tools can find them.
 
-https://github.com/embree/embree/releases/download/v3.13.2/embree-3.13.2.x64.vc14.msi .
+You can always add the embree3 folder to your library and include path by changing the LIB and INCLUDE environment variables:
 
-If you want to use the most recent version instead, make sure you unzip the contents of the zip file into the aforementioned folder.
+`` set INCLUDE="C:\Path\to\embree\include\dir:%INCLUDE%"
+set LIB="C:\Path\to\embree\lib\dir:%LIB%" ``
 
 You also still need to have build tools installed (some kind of C/C++ compiler). 
 One way to achieve this is to install Visual Studio Build tools. Visual studio 
 build tools likely require the installation of visual studio community edition first.
- This link should (hopefully) get you started: 
+This link should (hopefully) get you started: 
  
  https://visualstudio.microsoft.com/downloads/
 
-Finally, you'll need to manually copy the Embree3.dll from ``C:\Program Files\Intel\Embree3\bin`` to ``C:\windows\system32`` and
-(if you are on windows as you likely are these days) also to ``C:\windows\sysWOW64`` . That *should* do it...
+Finally, you'll need to manually copy the Embree3.dll from (standard path when installed) ``C:\Program Files\Intel\Embree3\bin`` 
+to ``C:\windows\system32`` and (if you are on windows as you likely are these days) also to ``C:\windows\sysWOW64`` . 
+That *should* do it...
 
 Requirements
 ============

--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,8 @@ zip file into a folder where the MS build tools can find them.
 
 You can always add the embree3 folder to your library and include path by changing the LIB and INCLUDE environment variables:
 
-`` set INCLUDE="C:\Path\to\embree\include\dir:%INCLUDE%"
-set LIB="C:\Path\to\embree\lib\dir:%LIB%" ``
+``set INCLUDE="C:\Path\to\embree\include\dir:%INCLUDE%"
+set LIB="C:\Path\to\embree\lib\dir:%LIB%"``
 
 You also still need to have build tools installed (some kind of C/C++ compiler). 
 One way to achieve this is to install Visual Studio Build tools. Visual studio 

--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,8 @@ zip file into a folder where the MS build tools can find them.
 
 You can always add the embree3 folder to your library and include path by changing the LIB and INCLUDE environment variables:
 
-``set INCLUDE="C:\Path\to\embree\include\dir:%INCLUDE%"
-set LIB="C:\Path\to\embree\lib\dir:%LIB%"``
+``set INCLUDE="C:\Path\to\embree\include\dir:%INCLUDE%"``
+``set LIB="C:\Path\to\embree\lib\dir:%LIB%"``
 
 You also still need to have build tools installed (some kind of C/C++ compiler). 
 One way to achieve this is to install Visual Studio Build tools. Visual studio 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Install from latest github source:
    ``python -m pip install --no-deps --no-build-isolation --user git+https://github.com/AppliedMathematicsANU/pyemblite.git#egg=pyemblite``
 
 If you're on windows, you need to have embree3 installed and in the default 
-location (C:\Program Files\Intel\Embree3\) before you install pyemblite. 
+location (``C:\Program Files\Intel\Embree3\``) before you install pyemblite. 
 To complicate matters, the most recent versions no longer come with an installer, 
 the last version to do so is this one:
 
@@ -79,8 +79,8 @@ build tools likely require the installation of visual studio community edition f
  
  https://visualstudio.microsoft.com/downloads/
 
-Finally, you'll need to manually copy the Embree3.dll from C:\Program Files\Intel\Embree3\bin to C:\windows\system32 and
-(if you are on windows as you likely are these days) also to C:\windows\sysWOW64 . That *should* do it...
+Finally, you'll need to manually copy the Embree3.dll from ``C:\Program Files\Intel\Embree3\bin`` to ``C:\windows\system32`` and
+(if you are on windows as you likely are these days) also to ``C:\windows\sysWOW64`` . That *should* do it...
 
 Requirements
 ============

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,9 @@ Install from latest github source:
 
    ``python -m pip install --no-deps --no-build-isolation --user git+git://github.com/AppliedMathematicsANU/pyemblite.git#egg=pyemblite``
 
+If you're on windows, you need to have embree3 installed and in the default location (C:\Program Files\Intel\Embree3\) before you install pyemblite. To complicate matters, the most recent versions no longer come with an installer, the last version to do so is this one: https://github.com/embree/embree/releases/download/v3.13.2/embree-3.13.2.x64.vc14.msi .
+If you want to use the most recent version instead, make sure you unzip the contents of the zip file into the aforementioned folder.
+You also still need to have build tools installed (some kind of C/C++ compiler). One way to achieve this is to install Visual Studio Build tools. Visual studio build tools likely require the installation of visual studio community edition first. This link should (hopefully) get you started: https://visualstudio.microsoft.com/downloads/
 
 Requirements
 ============

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ zip file into a folder where the MS build tools can find them.
 You can always add the embree3 folder to your library and include path by changing the LIB and INCLUDE environment variables:
 
 ``set INCLUDE="C:\Path\to\embree\include\dir:%INCLUDE%"``
+
 ``set LIB="C:\Path\to\embree\lib\dir:%LIB%"``
 
 You also still need to have build tools installed (some kind of C/C++ compiler). 

--- a/README.rst
+++ b/README.rst
@@ -61,11 +61,26 @@ Installation
 
 Install from latest github source:
 
-   ``python -m pip install --no-deps --no-build-isolation --user git+git://github.com/AppliedMathematicsANU/pyemblite.git#egg=pyemblite``
+   ``python -m pip install --no-deps --no-build-isolation --user git+https://github.com/AppliedMathematicsANU/pyemblite.git#egg=pyemblite``
 
-If you're on windows, you need to have embree3 installed and in the default location (C:\Program Files\Intel\Embree3\) before you install pyemblite. To complicate matters, the most recent versions no longer come with an installer, the last version to do so is this one: https://github.com/embree/embree/releases/download/v3.13.2/embree-3.13.2.x64.vc14.msi .
+If you're on windows, you need to have embree3 installed and in the default 
+location (C:\Program Files\Intel\Embree3\) before you install pyemblite. 
+To complicate matters, the most recent versions no longer come with an installer, 
+the last version to do so is this one:
+
+https://github.com/embree/embree/releases/download/v3.13.2/embree-3.13.2.x64.vc14.msi .
+
 If you want to use the most recent version instead, make sure you unzip the contents of the zip file into the aforementioned folder.
-You also still need to have build tools installed (some kind of C/C++ compiler). One way to achieve this is to install Visual Studio Build tools. Visual studio build tools likely require the installation of visual studio community edition first. This link should (hopefully) get you started: https://visualstudio.microsoft.com/downloads/
+
+You also still need to have build tools installed (some kind of C/C++ compiler). 
+One way to achieve this is to install Visual Studio Build tools. Visual studio 
+build tools likely require the installation of visual studio community edition first.
+ This link should (hopefully) get you started: 
+ 
+ https://visualstudio.microsoft.com/downloads/
+
+Finally, you'll need to manually copy the Embree3.dll from C:\Program Files\Intel\Embree3\bin to C:\windows\system32 and
+(if you are on windows as you likely are these days) also to C:\windows\sysWOW64 . That *should* do it...
 
 Requirements
 ============

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,8 @@ from Cython.Build import cythonize
 import Cython
 from distutils.version import LooseVersion
 
-if os.name.startswith('nt'):
-    # windows does not have an easy way to find libraries/install them in a standard location?
-    # to complicate things further, embree3 no longer comes with a windows installer, but the last
-    # version to do so had "C:\Program Files\Intel\Embree3\" as the default installation location
-    # so we'll use that.
-    
-    include_path = [np.get_include(), r'C:\Program Files\Intel\Embree3\include']
-    libs = [r"C:\Program Files\Intel\Embree3\lib\embree3"]
-else:
-    include_path = [np.get_include(),]
-    libs = ["embree3"]
+include_path = [np.get_include(), ]
+libs = ["embree3"]
 
 define_macros = []
 if LooseVersion(Cython.__version__) >= LooseVersion("3.0"):
@@ -45,7 +36,7 @@ ext_modules = cythonize(extensions, include_path=include_path, language_level=3)
 
 setup(
     name="pyemblite",
-    version='0.0.2',
+    version='0.0.1',
     ext_modules=ext_modules,
     zip_safe=False,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,17 @@ from Cython.Build import cythonize
 import Cython
 from distutils.version import LooseVersion
 
-include_path = [np.get_include(), ]
-libs = ["embree3"]
+if os.name.startswith('nt'):
+    # windows does not have an easy way to find libraries/install them in a standard location?
+    # to complicate things further, embree3 no longer comes with a windows installer, but the last
+    # version to do so had "C:\Program Files\Intel\Embree3\" as the default installation location
+    # so we'll use that.
+    
+    include_path = [np.get_include(), r'C:\Program Files\Intel\Embree3\']
+    libs = [r"C:\Program Files\Intel\Embree3\lib\embree3"]
+else:
+    include_path = [np.get_include(),]
+    libs = ["embree3"]
 
 define_macros = []
 if LooseVersion(Cython.__version__) >= LooseVersion("3.0"):
@@ -36,7 +45,7 @@ ext_modules = cythonize(extensions, include_path=include_path, language_level=3)
 
 setup(
     name="pyemblite",
-    version='0.0.1',
+    version='0.0.2',
     ext_modules=ext_modules,
     zip_safe=False,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if os.name.startswith('nt'):
     # version to do so had "C:\Program Files\Intel\Embree3\" as the default installation location
     # so we'll use that.
     
-    include_path = [np.get_include(), r'C:\Program Files\Intel\Embree3\']
+    include_path = [np.get_include(), r'C:\Program Files\Intel\Embree3']
     libs = [r"C:\Program Files\Intel\Embree3\lib\embree3"]
 else:
     include_path = [np.get_include(),]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if os.name.startswith('nt'):
     # version to do so had "C:\Program Files\Intel\Embree3\" as the default installation location
     # so we'll use that.
     
-    include_path = [np.get_include(), r'C:\Program Files\Intel\Embree3']
+    include_path = [np.get_include(), r'C:\Program Files\Intel\Embree3\include']
     libs = [r"C:\Program Files\Intel\Embree3\lib\embree3"]
 else:
     include_path = [np.get_include(),]


### PR DESCRIPTION
Added support for windows installation

Still far from perfect, but updated the documentation to indicate what needs
to be done to at least have a shot at this working.
Setup.py now explicitly checks what OS it is running on, and in case of windows
sets the location of embree to the standard install location.
Sorry, I am not aware of/could not get a more generic command line option which
adds to the library path to work, so this was ultimately what let me install
pyemblite on windows machines.
A weird quirk is that this only worked for me in the conda base environment, not
sure why it would fail in other environments...